### PR TITLE
Support commonjs

### DIFF
--- a/test/fixtures/cjs1.js
+++ b/test/fixtures/cjs1.js
@@ -1,0 +1,3 @@
+window.define(['require', 'module', 'exports'], function (require, module, exports) {
+  exports.value = 'cjs'
+})

--- a/test/fixtures/cjs2.js
+++ b/test/fixtures/cjs2.js
@@ -1,0 +1,3 @@
+window.define(['require', 'module', 'exports'], function (require, module, exports) {
+  module.exports = 'cjs'
+})

--- a/test/test-micro-amd.js
+++ b/test/test-micro-amd.js
@@ -90,4 +90,11 @@ describe('micro-amd', function () {
       expect(m).to.eql(3)
     })
   })
+
+  it('should allow cjs', function () {
+    return api.require(['cjs1', 'cjs2'], function (m1, m2) {
+      expect(m1).to.eql({ value: 'cjs' })
+      expect(m2).to.eql('cjs')
+    })
+  })
 })


### PR DESCRIPTION
we might not need this, but it

- is pretty simple to implement
- adds very little code
- makes micro-amd compliant with amd spec
